### PR TITLE
Add tool for improving the release process that outputs .pb.go files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@
 # User-specific .bazelrc
 user.bazelrc
 *.google.md
+
+# Don't include generated .pb.go files in the repo.
+*.pb.go

--- a/csvtoproto/csvtoproto.go
+++ b/csvtoproto/csvtoproto.go
@@ -133,7 +133,7 @@ func sortImports(paths []string) []string {
 		m[p] = true
 	}
 	var out []string
-	for key, _ := range m {
+	for key := range m {
 		out = append(out, key)
 	}
 	sort.Strings(out)

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,8 @@ require (
 	github.com/stoewer/go-strcase v1.2.0
 	google.golang.org/grpc v1.30.0
 	google.golang.org/protobuf v1.25.0
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/mitchellh/go-wordwrap v1.0.0
+	github.com/bazelbuild/rules_go v0.23.3
+	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 )

--- a/go.sum
+++ b/go.sum
@@ -53,6 +53,8 @@ golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAG
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a h1:1BGLXjeY4akVXGgbC9HugT3Jv3hCI0z56oJR5vAMgBU=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/proto/BUILD.bazel
+++ b/proto/BUILD.bazel
@@ -1,0 +1,4 @@
+# generate_pb_go_files can be used to output .pb.go files to subdirectories. Bazel
+# should not consider these generated files because it uses the .proto files.
+
+# gazelle:exclude **/*.pb.go

--- a/releasing/generate_pb_go_files/BUILD.bazel
+++ b/releasing/generate_pb_go_files/BUILD.bazel
@@ -1,0 +1,32 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["generate_pb_go_files.go"],
+    importpath = "github.com/google/xtoproto/releasing/generate_pb_go_files",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@com_github_golang_glog//:go_default_library",
+        "@io_bazel_rules_go//go/tools/bazel:go_default_library",
+        "@org_golang_x_sync//errgroup:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "generate_pb_go_files",
+    data = [
+        ":generated_sources",
+    ],
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "generated_sources",
+    srcs = [
+        "//proto/recordtoproto:recordtoproto_go_proto",
+        "//proto/service:service_go_proto",
+    ],
+    # Based on https://github.com/bazelbuild/rules_go/blob/740ada94dfda52f2a079f718858e8b2b8ee0fdc6/proto/def.bzl#L130
+    output_group = "go_generated_srcs",
+)

--- a/releasing/generate_pb_go_files/generate_pb_go_files.go
+++ b/releasing/generate_pb_go_files/generate_pb_go_files.go
@@ -1,0 +1,105 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Program generate_pb_go_files collects the generated go files from the bazel
+// runfiles directory that match a given prefix and outputs those files to a
+// destination directory; this may be used when .pb.go artifacts are needed to
+// build xtoproto without bazel.
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/bazelbuild/rules_go/go/tools/bazel"
+	"github.com/golang/glog"
+	"golang.org/x/sync/errgroup"
+)
+
+const (
+	outDirMode  os.FileMode = 0770
+	outFileMode os.FileMode = 0660
+)
+
+var (
+	importPath = flag.String("import_path", "github.com/google/xtoproto/proto", "import path used for generated proto files")
+	outputDir  = flag.String("output_dir", "", "output directory")
+)
+
+func main() {
+	flag.Parse()
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "fatal error: %v", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	rfe, err := bazel.ListRunfiles()
+	if err != nil {
+		return err
+	}
+
+	cfg := &config{
+		ImportPath: *importPath,
+		OutputDir:  *outputDir,
+	}
+	eg := &errgroup.Group{}
+	for _, e := range rfe {
+		e := e
+		eg.Go(func() error {
+			return cfg.maybeCopy(e)
+		})
+	}
+	return eg.Wait()
+}
+
+type config struct {
+	ImportPath string `json:"import_path"`
+	OutputDir  string `json:"output_dir"`
+}
+
+func (c *config) destination(e bazel.RunfileEntry) string {
+	idx := strings.Index(e.ShortPath, c.ImportPath+"/")
+	if idx == -1 || !strings.HasSuffix(e.ShortPath, ".go") {
+		return ""
+	}
+	rest := e.ShortPath[idx+len(c.ImportPath)+1:]
+	return filepath.Join(c.OutputDir, rest)
+}
+
+func (c *config) maybeCopy(e bazel.RunfileEntry) error {
+	dst := c.destination(e)
+	if dst == "" {
+		return nil
+	}
+	dir := filepath.Dir(dst)
+	if err := os.MkdirAll(dir, outDirMode); err != nil {
+		return err
+	}
+	contents, err := ioutil.ReadFile(e.Path)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile(dst, contents, outFileMode)
+	if err != nil {
+		return err
+	}
+	glog.Infof("finished copying %s", dst)
+	return nil
+}


### PR DESCRIPTION
Example usage:

```shell
bazel run //releasing/generate_pb_go_files -- -output_dir path/to/xtoproto-git/proto --alsologtostderr
```