### PR TITLE
Replace csv.Reader with RowReader interface.

### DIFF
--- a/csvcoder/csvcoder_file.go
+++ b/csvcoder/csvcoder_file.go
@@ -15,7 +15,6 @@
 package csvcoder
 
 import (
-	"encoding/csv"
 	"fmt"
 	"io"
 	"reflect"
@@ -25,7 +24,7 @@ import (
 
 // FileParser is an object used to parse an entire CSV file.
 type FileParser struct {
-	r        *csv.Reader
+	r        recordsReader
 	filePath string
 	rt       *registeredType
 
@@ -36,14 +35,20 @@ type FileParser struct {
 	fatalErr error
 }
 
+// recordsReader is an interface of a reader that reads raw records from the
+// data source. For example, csv.Reader is a recordsReader.
+type recordsReader interface {
+	Read() ([]string, error)
+}
+
 // NewFileParser returns an object for parsing a set of records from a file.
 //
-// The input CSV reader will be used to read all rows. The path argument is only
+// The input recordsReader will be used to read all rows. The path argument is only
 // for error reporting purposes.
 //
 // The type of the recordPrototype should have been registered with a call to
 // RegisterRowStruct.
-func NewFileParser(r *csv.Reader, path string, recordPrototype interface{}) (*FileParser, error) {
+func NewFileParser(r recordsReader, path string, recordPrototype interface{}) (*FileParser, error) {
 	rt, err := getOrRegisterType(reflect.ValueOf(recordPrototype).Type())
 	if err != nil {
 		return nil, fmt.Errorf("could not find or infer coder for type %v: %w", reflect.ValueOf(recordPrototype).Type(), err)

--- a/csvcoder/csvcoder_file.go
+++ b/csvcoder/csvcoder_file.go
@@ -24,7 +24,7 @@ import (
 
 // FileParser is an object used to parse an entire CSV file.
 type FileParser struct {
-	r        recordsReader
+	r        RowReader
 	filePath string
 	rt       *registeredType
 
@@ -35,20 +35,20 @@ type FileParser struct {
 	fatalErr error
 }
 
-// recordsReader is an interface of a reader that reads raw records from the
-// data source. For example, csv.Reader is a recordsReader.
-type recordsReader interface {
+// RowReader is an interface of a reader that reads raw records from the data
+// source. For example, csv.Reader is a RowReader.
+type RowReader interface {
 	Read() ([]string, error)
 }
 
 // NewFileParser returns an object for parsing a set of records from a file.
 //
-// The input recordsReader will be used to read all rows. The path argument is only
+// The input RowReader will be used to read all rows. The path argument is only
 // for error reporting purposes.
 //
 // The type of the recordPrototype should have been registered with a call to
 // RegisterRowStruct.
-func NewFileParser(r recordsReader, path string, recordPrototype interface{}) (*FileParser, error) {
+func NewFileParser(r RowReader, path string, recordPrototype interface{}) (*FileParser, error) {
 	rt, err := getOrRegisterType(reflect.ValueOf(recordPrototype).Type())
 	if err != nil {
 		return nil, fmt.Errorf("could not find or infer coder for type %v: %w", reflect.ValueOf(recordPrototype).Type(), err)


### PR DESCRIPTION
The standard csv.Reader is not flexible enough in some cases when it's
used as a data provider in FileParser.

For example, you can have a file in which you want to skip certain
lines. Sometimes Reader.Comment may be suitable if the lines you want
to skip all start with the same character. Though in other more complex
cases there is no way to configure csv.Reader to skip needed lines.

Intriduction of the recordsReader should help to close this gap: you'll
just need to write a custom wrapper around csv.Reader with custom logic
for skipping lines that need to be skipped.