### PR TITLE
Fix Sprintf() arguments.

### DIFF
--- a/textpos/textpos_from_go_token.go
+++ b/textpos/textpos_from_go_token.go
@@ -310,7 +310,7 @@ func (f *File) lineStartWithMutexHeld(line Line) Pos {
 		panic(fmt.Sprintf("invalid line %s", line))
 	}
 	if line.Ordinal() > len(f.lines) {
-		panic(fmt.Sprintf("invalid line %s", line, len(f.lines)))
+		panic(fmt.Sprintf("invalid line %s, expected max %d", line, len(f.lines)))
 	}
 	return Pos(f.base + f.lines[line.Offset()])
 }


### PR DESCRIPTION
The format string should have additional placeholder for len(f.lines).